### PR TITLE
Using code-mirror sytax-tree to detect  math block.

### DIFF
--- a/main.js
+++ b/main.js
@@ -9,6 +9,7 @@ module.exports = class AutoSwitchInputPlugin extends Plugin {
             switchToEnglish: 'com.apple.keylayout.ABC',
             switchToPrevious: 'com.tencent.inputmethod.wetype.pinyin',
             imeSelectorPath: '/opt/homebrew/bin/macism',
+            changed: false
         };
 
         this.settings = Object.assign({}, DEFAULT_SETTINGS);
@@ -49,6 +50,12 @@ function createExtension(settings) {
             }
         }
         switchIME() {
+            if (settings.changed)
+            {
+                settings.changed = false;
+                this.previousInputMethodCode = `${settings.imeSelectorPath} ${settings.switchToPrevious}`;
+                this.englishInputMethodCode = `${settings.imeSelectorPath} ${settings.switchToEnglish}`;
+            }
             if (this.isInsideMathBlock) {
                 this.switchToEnglishInput();
             } else {
@@ -122,6 +129,7 @@ class AutoSwitchInputSettingTab extends PluginSettingTab {
             .addText(text => text
                 .setValue(this.plugin.settings.switchToPrevious)
                 .onChange(async (value) => {
+                    this.plugin.settings.changed = true;
                     this.plugin.settings.switchToPrevious = value;
                     await this.plugin.saveSettings();
                 }));
@@ -132,6 +140,7 @@ class AutoSwitchInputSettingTab extends PluginSettingTab {
             .addText(text => text
                 .setValue(this.plugin.settings.imeSelectorPath)
                 .onChange(async (value) => {
+                    this.plugin.settings.changed = true;
                     this.plugin.settings.imeSelectorPath = value;
                     await this.plugin.saveSettings();
                 }));

--- a/main.js
+++ b/main.js
@@ -1,160 +1,139 @@
 const { Plugin, PluginSettingTab, Setting } = require('obsidian');
 const { exec } = require('child_process');
+var import_view = require("@codemirror/view");
+var import_language = require("@codemirror/language");
 
 module.exports = class AutoSwitchInputPlugin extends Plugin {
-    async onload() {
-        const DEFAULT_SETTINGS = {
-            switchToEnglish: 'macism com.apple.keylayout.ABC',
-            switchToPrevious: 'macism com.tencent.inputmethod.wetype.pinyin',
-            imeSelectorPath: '/opt/homebrew/bin',
-        };
+	async onload() {
+		const DEFAULT_SETTINGS = {
+			switchToEnglish: 'com.apple.keylayout.ABC',
+			switchToPrevious: 'com.tencent.inputmethod.wetype.pinyin',
+			imeSelectorPath: '/opt/homebrew/bin/macism',
+		};
 
-        this.settings = Object.assign({}, DEFAULT_SETTINGS);
+		this.settings = Object.assign({}, DEFAULT_SETTINGS);
 
-        await this.loadSettings();
+		await this.loadSettings();
 
-        this.registerEvent(this.app.workspace.on('editor-change', this.handleEditorChange.bind(this)));
-        this.addSettingTab(new AutoSwitchInputSettingTab(this.app, this));
+		this.registerEditorExtension(import_view.ViewPlugin.fromClass(createExtension(this.settings)));
+		this.addSettingTab(new AutoSwitchInputSettingTab(this.app, this));
 
-        this.previousInputMethod = '';
-        this.isInMathBlock = false;
-    }
+		this.previousInputMethod = '';
+		this.isInMathBlock = false;
+	}
 
-    async loadSettings() {
-        this.settings = Object.assign({}, this.settings, await this.loadData());
-    }
+	async loadSettings() {
+		this.settings = Object.assign({}, this.settings, await this.loadData());
+	}
 
-    async saveSettings() {
-        await this.saveData(this.settings);
-    }
-
-    handleEditorChange(editor, change) {
-        const content = editor.getValue();
-        const cursor = editor.getCursor();
-        const isNowInMathBlock = this.isInsideMathBlock(content, cursor.line, cursor.ch);
-
-        if (isNowInMathBlock && !this.isInMathBlock) {
-            this.switchToEnglishInput();
-        } else if (!isNowInMathBlock && this.isInMathBlock) {
-            this.switchToPreviousInputMethod();
-        }
-
-        this.isInMathBlock = isNowInMathBlock;
-    }
-
-    isInsideMathBlock(content, lineNum, cursorPosition) {
-        const lines = content.split('\n');
-        const line = lines[lineNum];
-
-        if (line.includes('$') && line.indexOf('$') !== line.lastIndexOf('$')) {
-            const startPos = line.indexOf('$');
-            const endPos = line.lastIndexOf('$');
-            if (cursorPosition >= startPos && cursorPosition <= endPos) {
-                return true;
-            }
-        }
-
-        let mathBlockStartLine = -1;
-        let mathBlockEndLine = -1;
-
-        for (let i = lineNum; i >= 0; i--) {
-            if (lines[i].includes('$$') && mathBlockStartLine === -1) {
-                mathBlockStartLine = i;
-                break;
-            }
-        }
-
-        for (let i = lineNum; i < lines.length; i++) {
-            if (lines[i].includes('$$') && i !== mathBlockStartLine) {
-                mathBlockEndLine = i;
-                break;
-            }
-        }
-
-        if (mathBlockStartLine !== -1 && mathBlockEndLine !== -1) {
-            const startLine = lines[mathBlockStartLine];
-            const endLine = lines[mathBlockEndLine];
-
-            const startPos = startLine.indexOf('$$');
-            const endPos = endLine.lastIndexOf('$$');
-
-            if (mathBlockStartLine === mathBlockEndLine) {
-                return cursorPosition >= startPos && cursorPosition <= endPos;
-            } else {
-                if (lineNum === mathBlockStartLine) {
-                    return cursorPosition >= startPos;
-                } else if (lineNum === mathBlockEndLine) {
-                    return cursorPosition <= endPos;
-                } else {
-                    return true;
-                }
-            }
-        }
-
-        return false;
-    }
-
-    switchToEnglishInput() {
-        const switchCammand = `${this.settings.imeSelectorPath}/${this.settings.switchToEnglish}`
-        exec(switchCammand, (err, stdout, stderr) => {
-            if (err) {
-                console.error('Error switching to English input method:', err);
-            } else {
-                console.log('Switched to English input method');
-            }
-        });
-    }
-
-    switchToPreviousInputMethod() {
-        const switchCammand = `${this.settings.imeSelectorPath}/${this.settings.switchToPrevious}`
-        exec(switchCammand, (err, stdout, stderr) => {
-            if (err) {
-                console.error('Error switching to previous input method:', err);
-            } else {
-                console.log('Switched back to previous input method');
-            }
-        });
-    }
+	async saveSettings() {
+		await this.saveData(this.settings);
+	}
 };
 
+function createExtension(settings) {
+	return class {
+		constructor(view) {
+			this.previousInputMethodCode = `${settings.imeSelectorPath} ${settings.switchToPrevious}`;
+			this.englishInputMethodCode = `${settings.imeSelectorPath} ${settings.switchToEnglish}`;
+			this.isInsideMathBlock = isInsideMathBlock(view);
+			this.switchIME();
+		}
+		update(update) {
+			if (update.docChanged || update.selectionSet) {
+				const currentInMath = isInsideMathBlock(update.view);
+				if (this.isInsideMathBlock != currentInMath) {
+					this.isInsideMathBlock = currentInMath;
+					this.switchIME();
+				}
+			}
+		}
+		switchIME() {
+			if (this.isInsideMathBlock) {
+				this.switchToEnglishInput();
+			} else {
+				this.switchToPreviousInputMethod();
+			}
+		}
+		switchToPreviousInputMethod() {
+			exec(this.previousInputMethodCode, (err, stdout, stderr) => {
+				if (err) {
+					console.error('Error switching to previous input method:', err);
+				} else {
+					console.log('Switched back to previous input method');
+				}
+			});
+		}
+		switchToEnglishInput() {
+			exec(this.englishInputMethodCode, (err, stdout, stderr) => {
+				if (err) {
+					console.error('Error switching to English input method:', err);
+				} else {
+					console.log('Switched to English input method');
+				}
+			});
+		}
+	};
+}
+
+function isInsideMathBlock(view) {
+	const state = view.state;
+	const pos = state.selection.main.to;
+	const tree = (0, import_language.syntaxTree)(state);
+	let syntaxNode = tree.resolveInner(pos, -1);
+	if (syntaxNode.name.contains("math-end"))
+		return false;
+	if (!syntaxNode.parent) {
+		syntaxNode = tree.resolveInner(pos, 1);
+		if (syntaxNode.name.contains("math-begin"))
+			return false;
+	}
+	if (!syntaxNode.parent) {
+		const left = tree.resolveInner(pos - 1, -1);
+		const right = tree.resolveInner(pos + 1, 1);
+		return left.name.contains("math") && right.name.contains("math") && !left.name.contains("math-end");
+	}
+	return syntaxNode.name.contains("math");
+}
+
 class AutoSwitchInputSettingTab extends PluginSettingTab {
-    constructor(app, plugin) {
-        super(app, plugin);
-        this.plugin = plugin;
-    }
+	constructor(app, plugin) {
+		super(app, plugin);
+		this.plugin = plugin;
+	}
 
-    display() {
-        const { containerEl } = this;
-        containerEl.empty();
+	display() {
+		const { containerEl } = this;
+		containerEl.empty();
 
-        new Setting(containerEl)
-            .setName('Switch to English IME command')
-            .setDesc('Enter the command to switch to English input method')
-            .addText(text => text
-                .setValue(this.plugin.settings.switchToEnglish)
-                .onChange(async (value) => {
-                    this.plugin.settings.switchToEnglish = value;
-                    await this.plugin.saveSettings();
-                }));
+		new Setting(containerEl)
+			.setName('Switch to English IME command args')
+			.setDesc('Enter the command to switch to English input method')
+			.addText(text => text
+				.setValue(this.plugin.settings.switchToEnglish)
+				.onChange(async (value) => {
+					this.plugin.settings.switchToEnglish = value;
+					await this.plugin.saveSettings();
+				}));
 
-        new Setting(containerEl)
-            .setName('Switch to previous IME command')
-            .setDesc('Enter the command to switch back to the previous input method')
-            .addText(text => text
-                .setValue(this.plugin.settings.switchToPrevious)
-                .onChange(async (value) => {
-                    this.plugin.settings.switchToPrevious = value;
-                    await this.plugin.saveSettings();
-                }));
+		new Setting(containerEl)
+			.setName('Switch to previous IME command args')
+			.setDesc('Enter the command to switch back to the previous input method')
+			.addText(text => text
+				.setValue(this.plugin.settings.switchToPrevious)
+				.onChange(async (value) => {
+					this.plugin.settings.switchToPrevious = value;
+					await this.plugin.saveSettings();
+				}));
 
-        new Setting(containerEl)
-            .setName('IME selector command path')
-            .setDesc('Enter the path to the command')
-            .addText(text => text
-                .setValue(this.plugin.settings.imeSelectorPath)
-                .onChange(async (value) => {
-                    this.plugin.settings.imeSelectorPath = value;
-                    await this.plugin.saveSettings();
-                }));
-    }
+		new Setting(containerEl)
+			.setName('IME selector command path args')
+			.setDesc('Enter the path to the command')
+			.addText(text => text
+				.setValue(this.plugin.settings.imeSelectorPath)
+				.onChange(async (value) => {
+					this.plugin.settings.imeSelectorPath = value;
+					await this.plugin.saveSettings();
+				}));
+	}
 }

--- a/main.js
+++ b/main.js
@@ -4,136 +4,136 @@ var import_view = require("@codemirror/view");
 var import_language = require("@codemirror/language");
 
 module.exports = class AutoSwitchInputPlugin extends Plugin {
-	async onload() {
-		const DEFAULT_SETTINGS = {
-			switchToEnglish: 'com.apple.keylayout.ABC',
-			switchToPrevious: 'com.tencent.inputmethod.wetype.pinyin',
-			imeSelectorPath: '/opt/homebrew/bin/macism',
-		};
+    async onload() {
+        const DEFAULT_SETTINGS = {
+            switchToEnglish: 'com.apple.keylayout.ABC',
+            switchToPrevious: 'com.tencent.inputmethod.wetype.pinyin',
+            imeSelectorPath: '/opt/homebrew/bin/macism',
+        };
 
-		this.settings = Object.assign({}, DEFAULT_SETTINGS);
+        this.settings = Object.assign({}, DEFAULT_SETTINGS);
 
-		await this.loadSettings();
+        await this.loadSettings();
 
-		this.registerEditorExtension(import_view.ViewPlugin.fromClass(createExtension(this.settings)));
-		this.addSettingTab(new AutoSwitchInputSettingTab(this.app, this));
+        this.registerEditorExtension(import_view.ViewPlugin.fromClass(createExtension(this.settings)));
+        this.addSettingTab(new AutoSwitchInputSettingTab(this.app, this));
 
-		this.previousInputMethod = '';
-		this.isInMathBlock = false;
-	}
+        this.previousInputMethod = '';
+        this.isInMathBlock = false;
+    }
 
-	async loadSettings() {
-		this.settings = Object.assign({}, this.settings, await this.loadData());
-	}
+    async loadSettings() {
+        this.settings = Object.assign({}, this.settings, await this.loadData());
+    }
 
-	async saveSettings() {
-		await this.saveData(this.settings);
-	}
+    async saveSettings() {
+        await this.saveData(this.settings);
+    }
 };
 
 function createExtension(settings) {
-	return class {
-		constructor(view) {
-			this.previousInputMethodCode = `${settings.imeSelectorPath} ${settings.switchToPrevious}`;
-			this.englishInputMethodCode = `${settings.imeSelectorPath} ${settings.switchToEnglish}`;
-			this.isInsideMathBlock = isInsideMathBlock(view);
-			this.switchIME();
-		}
-		update(update) {
-			if (update.docChanged || update.selectionSet) {
-				const currentInMath = isInsideMathBlock(update.view);
-				if (this.isInsideMathBlock != currentInMath) {
-					this.isInsideMathBlock = currentInMath;
-					this.switchIME();
-				}
-			}
-		}
-		switchIME() {
-			if (this.isInsideMathBlock) {
-				this.switchToEnglishInput();
-			} else {
-				this.switchToPreviousInputMethod();
-			}
-		}
-		switchToPreviousInputMethod() {
-			exec(this.previousInputMethodCode, (err, stdout, stderr) => {
-				if (err) {
-					console.error('Error switching to previous input method:', err);
-				} else {
-					console.log('Switched back to previous input method');
-				}
-			});
-		}
-		switchToEnglishInput() {
-			exec(this.englishInputMethodCode, (err, stdout, stderr) => {
-				if (err) {
-					console.error('Error switching to English input method:', err);
-				} else {
-					console.log('Switched to English input method');
-				}
-			});
-		}
-	};
+    return class {
+        constructor(view) {
+            this.previousInputMethodCode = `${settings.imeSelectorPath} ${settings.switchToPrevious}`;
+            this.englishInputMethodCode = `${settings.imeSelectorPath} ${settings.switchToEnglish}`;
+            this.isInsideMathBlock = isInsideMathBlock(view);
+            this.switchIME();
+        }
+        update(update) {
+            if (update.docChanged || update.selectionSet) {
+                const currentInMath = isInsideMathBlock(update.view);
+                if (this.isInsideMathBlock != currentInMath) {
+                    this.isInsideMathBlock = currentInMath;
+                    this.switchIME();
+                }
+            }
+        }
+        switchIME() {
+            if (this.isInsideMathBlock) {
+                this.switchToEnglishInput();
+            } else {
+                this.switchToPreviousInputMethod();
+            }
+        }
+        switchToPreviousInputMethod() {
+            exec(this.previousInputMethodCode, (err, stdout, stderr) => {
+                if (err) {
+                    console.error('Error switching to previous input method:', err);
+                } else {
+                    console.log('Switched back to previous input method');
+                }
+            });
+        }
+        switchToEnglishInput() {
+            exec(this.englishInputMethodCode, (err, stdout, stderr) => {
+                if (err) {
+                    console.error('Error switching to English input method:', err);
+                } else {
+                    console.log('Switched to English input method');
+                }
+            });
+        }
+    };
 }
 
 function isInsideMathBlock(view) {
-	const state = view.state;
-	const pos = state.selection.main.to;
-	const tree = (0, import_language.syntaxTree)(state);
-	let syntaxNode = tree.resolveInner(pos, -1);
-	if (syntaxNode.name.contains("math-end"))
-		return false;
-	if (!syntaxNode.parent) {
-		syntaxNode = tree.resolveInner(pos, 1);
-		if (syntaxNode.name.contains("math-begin"))
-			return false;
-	}
-	if (!syntaxNode.parent) {
-		const left = tree.resolveInner(pos - 1, -1);
-		const right = tree.resolveInner(pos + 1, 1);
-		return left.name.contains("math") && right.name.contains("math") && !left.name.contains("math-end");
-	}
-	return syntaxNode.name.contains("math");
+    const state = view.state;
+    const pos = state.selection.main.to;
+    const tree = (0, import_language.syntaxTree)(state);
+    let syntaxNode = tree.resolveInner(pos, -1);
+    if (syntaxNode.name.contains("math-end"))
+        return false;
+    if (!syntaxNode.parent) {
+        syntaxNode = tree.resolveInner(pos, 1);
+        if (syntaxNode.name.contains("math-begin"))
+            return false;
+    }
+    if (!syntaxNode.parent) {
+        const left = tree.resolveInner(pos - 1, -1);
+        const right = tree.resolveInner(pos + 1, 1);
+        return left.name.contains("math") && right.name.contains("math") && !left.name.contains("math-end");
+    }
+    return syntaxNode.name.contains("math");
 }
 
 class AutoSwitchInputSettingTab extends PluginSettingTab {
-	constructor(app, plugin) {
-		super(app, plugin);
-		this.plugin = plugin;
-	}
+    constructor(app, plugin) {
+        super(app, plugin);
+        this.plugin = plugin;
+    }
 
-	display() {
-		const { containerEl } = this;
-		containerEl.empty();
+    display() {
+        const { containerEl } = this;
+        containerEl.empty();
 
-		new Setting(containerEl)
-			.setName('Switch to English IME command args')
-			.setDesc('Enter the command to switch to English input method')
-			.addText(text => text
-				.setValue(this.plugin.settings.switchToEnglish)
-				.onChange(async (value) => {
-					this.plugin.settings.switchToEnglish = value;
-					await this.plugin.saveSettings();
-				}));
+        new Setting(containerEl)
+            .setName('Switch to English IME command args')
+            .setDesc('Enter the command to switch to English input method')
+            .addText(text => text
+                .setValue(this.plugin.settings.switchToEnglish)
+                .onChange(async (value) => {
+                    this.plugin.settings.switchToEnglish = value;
+                    await this.plugin.saveSettings();
+                }));
 
-		new Setting(containerEl)
-			.setName('Switch to previous IME command args')
-			.setDesc('Enter the command to switch back to the previous input method')
-			.addText(text => text
-				.setValue(this.plugin.settings.switchToPrevious)
-				.onChange(async (value) => {
-					this.plugin.settings.switchToPrevious = value;
-					await this.plugin.saveSettings();
-				}));
+        new Setting(containerEl)
+            .setName('Switch to previous IME command args')
+            .setDesc('Enter the command to switch back to the previous input method')
+            .addText(text => text
+                .setValue(this.plugin.settings.switchToPrevious)
+                .onChange(async (value) => {
+                    this.plugin.settings.switchToPrevious = value;
+                    await this.plugin.saveSettings();
+                }));
 
-		new Setting(containerEl)
-			.setName('IME selector command path args')
-			.setDesc('Enter the path to the command')
-			.addText(text => text
-				.setValue(this.plugin.settings.imeSelectorPath)
-				.onChange(async (value) => {
-					this.plugin.settings.imeSelectorPath = value;
-					await this.plugin.saveSettings();
-				}));
-	}
+        new Setting(containerEl)
+            .setName('IME selector command path args')
+            .setDesc('Enter the path to the command')
+            .addText(text => text
+                .setValue(this.plugin.settings.imeSelectorPath)
+                .onChange(async (value) => {
+                    this.plugin.settings.imeSelectorPath = value;
+                    await this.plugin.saveSettings();
+                }));
+    }
 }


### PR DESCRIPTION
#### Change

- Using code-mirror sytax-tree to detect  math block. Code-mirror provides syntax-tree for detecting math block. Using code-mirror api may provide better performance.
- Changing the settings format. From `${path}/${command}` to `${command} ${args}`. The former is strange for me, since it uses duplicate `macism` in `${command}`. In addition, Windows uses `\` instead of `/` in command line.
- Add passive settings change. The command to switch ime will only change when settings changes, taking less memory.